### PR TITLE
Fix incorrect bootstrap3 SCSS import path

### DIFF
--- a/app/client/stylesheets/main.scss
+++ b/app/client/stylesheets/main.scss
@@ -1,4 +1,4 @@
-@import '.meteor/local/build/programs/server/assets/packages/reywood_bootstrap3-sass/bootstrap';
+@import '.meteor/local/build/programs/server/assets/packages/reywood_bootstrap3-sass/_bootstrap';
 
 // NAVBAR
 .navbar {


### PR DESCRIPTION
It looks like the name of the file changed from "bootstrap" to "_bootstrap".

![Bootstrap](http://cl.ly/image/3M1x2H242g2A/Image%202015-08-29%20at%205.38.45%20p.%20m..png)
